### PR TITLE
Added client example for gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,10 @@ This project covers usage of gRPC in a Spring Boot application
   
 ```
 
+## Commands used for client
+```
+curl 'http://localhost:8080/greeting?message=Hello from client'
+```
+
 ## Reference
 - [Mike's Spring Boot gRPC Starter](https://yidongnan.github.io/grpc-spring-boot-starter/en/server/getting-started.html)

--- a/greeting-client/pom.xml
+++ b/greeting-client/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.5.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.techprimers</groupId>
+    <artifactId>grpc-spring-boot-client-example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>grpc-spring-boot-example</name>
+    <description>Demo project for Spring Boot</description>
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.devh</groupId>
+            <artifactId>grpc-client-spring-boot-starter</artifactId>
+            <version>2.12.0.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.techprimers</groupId>
+            <artifactId>greeting-common</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/greeting-client/src/main/java/com/techprimers/grpc/GrpcSpringBootClientExampleApplication.java
+++ b/greeting-client/src/main/java/com/techprimers/grpc/GrpcSpringBootClientExampleApplication.java
@@ -1,0 +1,12 @@
+package com.techprimers.grpc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GrpcSpringBootClientExampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GrpcSpringBootClientExampleApplication.class, args);
+    }
+}

--- a/greeting-client/src/main/java/com/techprimers/grpc/controller/GreetingController.java
+++ b/greeting-client/src/main/java/com/techprimers/grpc/controller/GreetingController.java
@@ -1,0 +1,22 @@
+package com.techprimers.grpc.controller;
+
+import com.techprimers.grpc.service.GreetingService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GreetingController {
+
+    private final GreetingService greetingService;
+
+    public GreetingController(GreetingService greetingService) {
+        this.greetingService = greetingService;
+    }
+
+    @GetMapping("/greeting")
+    public String getGreetingMessage(@RequestParam(value = "message",
+            defaultValue = "Hello") String message) {
+        return greetingService.receiveGreeting(message);
+    }
+}

--- a/greeting-client/src/main/java/com/techprimers/grpc/service/GreetingService.java
+++ b/greeting-client/src/main/java/com/techprimers/grpc/service/GreetingService.java
@@ -1,0 +1,26 @@
+package com.techprimers.grpc.service;
+
+import com.techprimers.grpc.GreetingRequest;
+import com.techprimers.grpc.GreetingResponse;
+import com.techprimers.grpc.GreetingServiceGrpc;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GreetingService {
+
+    @GrpcClient("grpc-server")
+    private GreetingServiceGrpc.GreetingServiceBlockingStub greetingServiceStub;
+
+    public String receiveGreeting(String message) {
+        GreetingRequest greetingRequest = GreetingRequest.newBuilder()
+                .setMessage(message)
+                .build();
+
+        //call to grpc server
+        GreetingResponse greetingResponse = greetingServiceStub.greeting(greetingRequest);
+
+        System.out.println("Received Message In Client: " + greetingResponse.getMessage());
+        return greetingResponse.getMessage();
+    }
+}

--- a/greeting-client/src/main/resources/application.properties
+++ b/greeting-client/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+grpc.client.grpc-server.address = static://localhost:9090
+grpc.client.grpc-server.enableKeepAlive = true
+grpc.client.grpc-server.keepAliveWithoutCalls = true
+grpc.client.grpc-server.negotiationType = plaintext

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,6 @@
     <modules>
         <module>greeting-common</module>
         <module>greeting-service</module>
+        <module>greeting-client</module>
     </modules>
 </project>


### PR DESCRIPTION
@MovingToWeb

Added example for gRPC client.

Created a new module named greeting-client. It exposes one REST endoint `/greeting` which will internally call the gRPC service and returns the message returned by gRPC service.

